### PR TITLE
Rename the gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    feature_flags (0.1.0)
+    govuk_feature_flags (0.1.0)
       rails (>= 7.0.4)
 
 GEM
@@ -131,8 +131,6 @@ GEM
       activesupport (>= 6.1.4.4)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jsbundling-rails (1.0.3)
-      railties (>= 6.0.0)
     json (2.6.2)
     loofah (2.19.0)
       crass (~> 1.0.2)
@@ -293,10 +291,9 @@ DEPENDENCIES
   cssbundling-rails
   cuprite
   factory_bot_rails
-  feature_flags!
   govuk-components
   govuk_design_system_formbuilder
-  jsbundling-rails
+  govuk_feature_flags!
   pg
   prettier_print
   propshaft

--- a/app/models/feature_flags/feature_flag.rb
+++ b/app/models/feature_flags/feature_flag.rb
@@ -11,7 +11,7 @@ module FeatureFlags
     end
 
     FEATURES =
-      FeatureFlags
+      GovukFeatureFlags
         .config
         .fetch("feature_flags", {})
         .to_h do |name, values|

--- a/govuk_feature_flags.gemspec
+++ b/govuk_feature_flags.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/feature_flags/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "feature_flags"
+  spec.name = "govuk_feature_flags"
   spec.version = FeatureFlags::VERSION
   spec.authors = ["Felix Clack"]
   spec.email = ["felix.clack@digital.education.gov.uk"]

--- a/lib/govuk_feature_flags.rb
+++ b/lib/govuk_feature_flags.rb
@@ -3,7 +3,7 @@
 require "feature_flags/version"
 require "feature_flags/engine"
 
-module FeatureFlags
+module GovukFeatureFlags
   def self.config_path
     path = defined?(Rails) ? Rails.root : File
     path.join("config", "feature_flags.yml")

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -19,7 +19,7 @@ require "action_view/railtie"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-require "feature_flags"
+require "govuk_feature_flags"
 
 module Dummy
   class Application < Rails::Application


### PR DESCRIPTION
The gem was originally named feature_flags. In order to make it clearer
that this has an implementation specific to gov.uk, we're adding a
prefix to the name.
