### PR TITLE
Enable access to parent app helpers

### DIFF
--- a/app/controllers/feature_flags/application_controller.rb
+++ b/app/controllers/feature_flags/application_controller.rb
@@ -3,6 +3,7 @@
 module FeatureFlags
   class ApplicationController < ActionController::Base
     layout -> { GovukFeatureFlags.config.fetch("layout", "application") }
+    helper all_helpers_from_path "app/helpers"
 
     default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
   end


### PR DESCRIPTION
By default, the engine isn't able to access the parent app's helper
methods.

A common pattern we have used in GOVUK services is to generate the
appropriate service header in a helper method that contains the logic of
which navigation elements to include based on the route namespace.

Including all the parent's app helpers is a catch all solution to reduce
the element of surprise when building services.
