### PR TITLE
Make parent controller configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ feature_flags:
     description: Allow users to access the service
 ```
 
+`FeatureFlagsController` can be configured to inherit from a controller in the parent application, useful if you want to mount behind authentication or to inherit other behaviours.
+
+```yaml
+parent_controller: 'SupportInterface::SupportInterfaceController'
+feature_flags:
+    ...
+```
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/app/controllers/feature_flags/application_controller.rb
+++ b/app/controllers/feature_flags/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FeatureFlags
-  class ApplicationController < ActionController::Base
+  class ApplicationController < GovukFeatureFlags.parent_controller.constantize
     layout -> { GovukFeatureFlags.config.fetch("layout", "application") }
     helper all_helpers_from_path "app/helpers"
 

--- a/lib/govuk_feature_flags.rb
+++ b/lib/govuk_feature_flags.rb
@@ -16,4 +16,8 @@ module GovukFeatureFlags
   def self.config=(config)
     @config = config
   end
+
+  def self.parent_controller
+    config.fetch("parent_controller", "ApplicationController")
+  end
 end

--- a/spec/dummy/app/controllers/custom_controller.rb
+++ b/spec/dummy/app/controllers/custom_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CustomController < ApplicationController
+  before_action { flash[:message] = "Custom controller!" }
+end

--- a/spec/dummy/config/feature_flags.yml
+++ b/spec/dummy/config/feature_flags.yml
@@ -1,3 +1,4 @@
+parent_controller: "CustomController"
 feature_flags:
   service_open:
     author: Felix Clack

--- a/spec/system/support_spec.rb
+++ b/spec/system/support_spec.rb
@@ -21,10 +21,26 @@ RSpec.describe "Feature Flags", type: :system do
     then_i_see_the_custom_layout
   end
 
+  it "customising parent_controller" do
+    given_i_configured_a_custom_parent_controller
+    when_i_visit_the_feature_flags_page
+    then_custom_controller_behaviours_are_triggered
+  end
+
   private
 
   def given_there_is_a_feature
     create(:feature)
+  end
+
+  def given_i_configured_a_custom_parent_controller
+    GovukFeatureFlags.config = {
+      "parent_controller" => "CustomController"
+    }
+  end
+
+  def then_custom_controller_behaviours_are_triggered
+    expect(page).to have_content("Custom controller!")
   end
 
   def given_i_configured_a_custom_layout


### PR DESCRIPTION
It's common for feature flags to be part of an admin section of the parent application.

This PR allows a `parent_controller` to be configured in the `config/feature_flags.yml` file of the parent application.
The idea for this comes from the [Devise gem](https://github.com/heartcombo/devise/blob/8593801130f2df94a50863b5db535c272b00efe1/lib/devise.rb#L230-L234)
The mounted `FeatureFlagsController` from the engine will inherit from the configured parent controller.

One issue I ran into when adding to the support spec is that the dummy application mounts the engine before the configuration can be altered for the purposes of testing, so the dummy application needs to be configured with a `parent_controller` to allow the relevant test to pass.
