### PR TITLE
Remove required_ruby_version

### DIFF
--- a/govuk_feature_flags.gemspec
+++ b/govuk_feature_flags.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/DFEDigital/refer-serious-misconduct"
   spec.summary = "Summary of FeatureFlags."
   spec.description = "Description of FeatureFlags."
-  spec.required_ruby_version = "~>3.1.2"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the "allowed_push_host"
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
Having this value set will not allow the projects that are using the gem to upgrade to Ruby 3.2