### PR TITLE
Disable RequiredRubyVersion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ inherit_mode:
   merge:
     - Exclude
 
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Lint/SuppressedException:
   Exclude:
     - lib/feature_flags/engine.rb


### PR DESCRIPTION
We don't do anything specific to the Ruby version so can disable this
cop.