### PR TITLE
Fix for Rubocop linting

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,7 +49,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = Rails.root.join("spec/fixtures")
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
We have a cop that prefers using `Rails.root.join` over string
interpolation.

This change addresses that cop so we can upgrade the Rubocop version.